### PR TITLE
Fix uncaught reference error when scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "dist/nz-tour.min.css"
     ],
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "build": "gulp build"
     },
     "repository": {
         "type": "git",

--- a/src/nz-tour.js
+++ b/src/nz-tour.js
@@ -141,7 +141,7 @@
                     }
                 }
                 return true;
-            }
+            };
 
             if (!validPriorities(tour.config.placementPriority)) {
                 tour.config.placementPriority = service.config.placementPriority;
@@ -586,7 +586,7 @@
                     };
 
 
-                    // Scrollbox 
+                    // Scrollbox
 
                     dims.scroll = {
                         width: els.scroll.outerWidth(),

--- a/src/nz-tour.js
+++ b/src/nz-tour.js
@@ -481,7 +481,7 @@
                     if (up && !scrollTop) {
                         return prevent(e);
                     }
-                    if (!up && (innerContent.height() - content.height() == scrollTop)) {
+                    if (!up && (els.innerContent.height() - els.content.height() == scrollTop)) {
                         return prevent(e);
                     }
                 }


### PR DESCRIPTION
Fix uncaught reference error when scrolling (e.g. call to `innerContent` instead of `els.innerContent`).

Also linking `npm build` to `gulp build` along with some minor style changes. I can remove these if you want.
