### PR TITLE
Fix off-by-one bug in `gotoStep`

### DIFF
--- a/src/nz-tour.js
+++ b/src/nz-tour.js
@@ -114,7 +114,7 @@
             if (i > 0 && i <= service.current.tour.steps.length) {
                 return doAfter()
                     .then(function() {
-                        service.current.step = i;
+                        service.current.step = i - 1;
                     })
                     .then(doStep);
             }


### PR DESCRIPTION
This assumes that `service.current.step` is counting from 0, which seems to be the case.

Closes nozzle/nzTour#1
