### PR TITLE
Allow setting max width and max height property in the code.

### DIFF
--- a/src/nz-tour.js
+++ b/src/nz-tour.js
@@ -293,8 +293,8 @@
                     target = false,
                     seeking = false,
                     margin = 15,
-                    maxHeight = 120,
-                    maxWidth = 250,
+                    maxHeight = (config.maxHeight)?config.maxHeight: 120,
+                    maxWidth = (config.maxWidth)?config.maxWidth: 250,
                     scrolling = false,
                     maskTransitions = true,
                     currentStep = null;


### PR DESCRIPTION
Allow setting max width and max height property in the code. This (in addition to CSS changes) allows to properly resize the particular tour. Without this code, if you only change the max-width property in the CSS  file, the positioning of the tour will not be correctly computed.
